### PR TITLE
Make layout responsive

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,11 +1,12 @@
 // src/components/Header.jsx
-import React, { useContext } from "react";
+import React, { useContext, useState } from "react";
 import { useNavigate, Link } from "react-router-dom";
 import { AuthContext } from "../AuthContext";
 
 function Header() {
   const navigate = useNavigate();
   const { isAuthenticated, userData } = useContext(AuthContext);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   return (
     <header className="flex items-center justify-between w-full max-w-7xl relative h-[113px] mx-auto">
@@ -15,7 +16,15 @@ function Header() {
       >
         GameWorld
       </h1>
-      <nav className="absolute left-1/2 -translate-x-1/2 flex gap-10 items-center">
+      <button
+        onClick={() => setMenuOpen(!menuOpen)}
+        className="md:hidden text-2xl px-2"
+      >
+        ☰
+      </button>
+      <nav
+        className={`${menuOpen ? 'flex' : 'hidden'} absolute md:static left-0 top-full md:top-auto md:left-1/2 md:-translate-x-1/2 flex-col md:flex-row gap-4 md:gap-10 items-center bg-[#18213A] md:bg-transparent w-full md:w-auto p-4 md:p-0`}
+      >
         <Link to="/news" className="text-[20px] hover:text-[#4A90E2]">Новости</Link>
         <Link to="/reviews" className="text-[20px] hover:text-[#4A90E2]">Обзоры</Link>
         <Link to="/video" className="text-[20px] hover:text-[#4A90E2]">Видео</Link>

--- a/src/components/NewsCard.jsx
+++ b/src/components/NewsCard.jsx
@@ -2,11 +2,11 @@ import React from "react";
 
 function NewsCard({ title, image, description, views }) {
   return (
-    <div className="w-[420px] h-[435px] bg-[#1B2234] rounded-[10px] overflow-hidden text-white font-['Play'] flex flex-col">
+    <div className="w-full md:w-[420px] bg-[#1B2234] rounded-[10px] overflow-hidden text-white font-['Play'] flex flex-col">
       <img
         src={image}
         alt={title}
-        className="w-full h-[220px] object-cover rounded-[10px] "
+        className="w-full h-48 md:h-[220px] object-cover rounded-[10px]"
       />
       <div className="p-4 flex flex-col justify-between h-full">
         <div className="text-2xl font-bold leading-9 mb-2">{title}</div>

--- a/src/components/ReviewCard.jsx
+++ b/src/components/ReviewCard.jsx
@@ -3,11 +3,11 @@ import React from "react";
 
 function ReviewCard({ review }) {
   return (
-    <div className="flex bg-[#1B2234] rounded-[8px] overflow-hidden mb-6">
+    <div className="flex flex-col md:flex-row bg-[#1B2234] rounded-[8px] overflow-hidden mb-6">
       <img
         src={review.image}
         alt={review.title}
-        className="w-[240px] h-[160px] object-cover"
+        className="w-full md:w-[240px] h-[160px] object-cover"
       />
       <div className="flex-1 p-4 relative">
         <h3 className="text-white text-xl font-bold font-play mb-1">{review.title}</h3>

--- a/src/components/VideoCard.jsx
+++ b/src/components/VideoCard.jsx
@@ -3,8 +3,8 @@ import { Play } from "lucide-react";
 
 const VideoCard = ({ title, image }) => {
   return (
-    <div className="w-[416px] h-[384px] bg-[#1B2234] rounded-[10px] overflow-hidden font-play">
-      <div className="relative h-[240px] bg-gray-200">
+    <div className="w-full md:w-[416px] bg-[#1B2234] rounded-[10px] overflow-hidden font-play">
+      <div className="relative h-60 md:h-[240px] bg-gray-200">
         <img
           src={image}
           alt="video preview"

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -92,7 +92,7 @@ function Main() {
 
         {/* Banner */}
 <section className="pt-4">
-  <div className="relative w-[1310px] h-[583px] overflow-hidden rounded-[10px] mx-auto">
+  <div className="relative w-full max-w-7xl h-[300px] md:h-[583px] overflow-hidden rounded-[10px] mx-auto">
     {/* Слайды */}
     <div
       className="flex h-full transition-transform duration-700 ease-in-out"

--- a/src/pages/NewsArticlePage.jsx
+++ b/src/pages/NewsArticlePage.jsx
@@ -83,7 +83,7 @@ if (!hasSentView.current && userData?.email) {
           <p className="text-sm text-gray-400 mb-4">
             {news.author} • Просмотров: {news.views}
           </p>
-          <img src={news.image} alt={news.title} className="w-full h-[400px] object-cover rounded mb-6" />
+          <img src={news.image} alt={news.title} className="w-full h-60 md:h-[400px] object-cover rounded mb-6" />
           <p className="text-lg text-[#D1D5DB] whitespace-pre-wrap mb-6">{news.content}</p>
 
         <h2 className="text-xl font-bold mb-2">Комментарии</h2>

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -248,7 +248,7 @@ const handleSave = async (e) => {
     <div className="min-h-screen bg-[#0e1525] text-white font-sans">
       <Header />
       
-      <div className="relative flex px-10 pt-10">
+      <div className="relative flex flex-col md:flex-row px-4 md:px-10 pt-10">
         {showMessageBox && (
           <div
             className={`fixed top-5 right-5 z-50 px-4 py-2 rounded shadow-lg text-white transition-all duration-500 transform ${
@@ -259,7 +259,7 @@ const handleSave = async (e) => {
           </div>
         )}
 
-        <aside className="bg-[#18213A] p-6 rounded-lg w-64 text-center">
+        <aside className="bg-[#18213A] p-6 rounded-lg w-full md:w-64 text-center">
           <img
             src={userData?.avatar ? `http://172.19.0.1:5001${userData.avatar}` : "/default-avatar.png"}
             alt="Аватар"
@@ -366,7 +366,7 @@ const handleSave = async (e) => {
           </button>
         </aside>
 
-        <main className="flex-1 ml-10">
+        <main className="flex-1 md:ml-10 mt-10 md:mt-0">
           <div className="flex gap-4 mb-6">
             <button
               className={`px-4 py-2 font-bold rounded ${activeTab === "achievements" ? "bg-[#4A90E2]" : "bg-[#1B2234]"}`}

--- a/src/pages/ReviewPage.jsx
+++ b/src/pages/ReviewPage.jsx
@@ -120,7 +120,7 @@ useEffect(() => {
         <img
           src={review.image}
           alt={review.game}
-          className="rounded w-full h-[600px] object-contain mb-8"
+          className="rounded w-full h-60 md:h-[600px] object-contain mb-8"
         />
 
 

--- a/src/pages/ReviewsPage.jsx
+++ b/src/pages/ReviewsPage.jsx
@@ -49,11 +49,11 @@ function ReviewsPage() {
         {/* Reviews List */}
         <div className="w-full max-w-7xl flex flex-col gap-4">
           {reviews.map((review, index) => (
-            <div key={index} className="bg-[#1B2234] rounded-lg overflow-hidden flex">
+            <div key={index} className="bg-[#1B2234] rounded-lg overflow-hidden flex flex-col md:flex-row">
                   <img
                     src={review.image}
                     alt={review.game}
-                    className="w-[428px] h-[228px] object-cover flex-shrink-0"
+                    className="w-full md:w-[428px] h-40 md:h-[228px] object-cover flex-shrink-0"
                   />
 
               <div className="p-4 flex-1">


### PR DESCRIPTION
## Summary
- add mobile menu to header
- tweak card components and pages for responsive widths and heights
- adjust profile page layout for small screens

## Testing
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68435be0143c8324aee8ab6c93592ba3